### PR TITLE
[#4]: Add CLI flag configuration 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+## Changelog
+
+## Testing
+
+## Ticket
+
+## Screenshot(s)
+
+## Checklist
+- [ ] I have tested the code in this pull request.
+- [ ] I have updated the Changelog.
+- [ ] I have documented any new features or changes in the Readme.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/paulshryock/release-bump/compare/HEAD..1.0.0)
 
 ### Added
-- Add CLI flag configuration.
+- Add CLI flag configuration. [#4]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/paulshryock/release-bump/compare/HEAD..1.0.0)
 
 ### Added
+- Add CLI flag configuration.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Release Bump
+# `release-bump`
 
-Release Bump handles version bump tasks for a code release.
+`release-bump` handles version bump tasks for a code release.
 
 ## Features
 
@@ -8,15 +8,11 @@ Release Bump handles version bump tasks for a code release.
 
 ### Bump Changelog
 
-From this:
+Add lines to your Changelog beneath the Unreleased header as you make changes. 
+
+`release-bump` will change this:
 
 ```bash
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## [Unreleased]
 
 ### Added
@@ -38,12 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 to this:
 
 ```bash
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## [Unreleased](https://example.com/repo/compare/HEAD..1.0.0)
 
 ### Added
@@ -88,11 +78,21 @@ Add `release-bump` to a `version` npm script.
 }
 ```
 
-Now whenever you run `npm version <major|minor|patch>`, all of the Release Bump tasks will execute with the new version number before npm creates a version commit.
+Now whenever you run `npm version <major|minor|patch>`, all of the `release-bump` tasks will execute with the new version number before npm creates a version commit.
+
+#### Configuration
+
+| Option | Type    | Default                                | Description                            |
+| :---   | :---    | :---                                   | :---                                   |
+| `-p`   | string  | `./CHANGELOG.md`                       | The Changelog file path.               |
+| `-r`   | string  | `github`                               | The Git remote. (`github`|`bitbucket`) |
+| `-s`   | boolean | `false`                                | Whether to skip `v` in the version.    |
+| `-t`   | string  | empty string                           | The initial Changelog text.            |
+| `-u`   | string  | `https://keepachangelog.com/en/1.0.0/` | The initial Changelog text URL.        |
 
 ### JavaScript API
 
-If you prefer to run Release Bump programattically, just require Release Bump as a class and instantiate it:
+If you prefer to run `release-bump` programattically, just require and instantiate a `release-bump` class:
 
 ```javascript
 const Bump = require('release-bump')
@@ -106,21 +106,21 @@ const Bump = require('release-bump')
 new Bump({
   changelog: {
     filePath: './CHANGELOG.md',
-    includeV: true,
+    gitRemote: 'github',
     initialText: '',
     initialTextUrl: 'https://keepachangelog.com/en/1.0.0/',
-    remote: 'github',
-  }
+    skipV: false,
+  },
 })
 ```
 
 #### Configuration
 
-| Option                     | Type    | Default                                | Description                          |
-| :---                       | :---    | :---                                   | :---                                 |
-| `changelog`                | Object  |                                        | The Changelog options.               |
-| `changelog.filePath`       | string  | `./CHANGELOG.md`                       | The Changelog file path.             |
-| `changelog.includeV`       | boolean | `true`                                 | Whether to include v in the version. |
-| `changelog.initialText`    | string  | empty string                           | The initial Changelog text.          |
-| `changelog.initialTextUrl` | string  | `https://keepachangelog.com/en/1.0.0/` | The initial Changelog text URL.      |
-| `changelog.remote`         | string  | `github`                               | Accepts `github` or `bitbucket`.     |
+| Option                     | Type    | Default                                | Description                            |
+| :---                       | :---    | :---                                   | :---                                   |
+| `changelog`                | Object  |                                        | The Changelog options.                 |
+| `changelog.filePath`       | string  | `./CHANGELOG.md`                       | The Changelog file path.               |
+| `changelog.gitRemote`      | string  | `github`                               | The Git remote. (`github`|`bitbucket`) |
+| `changelog.initialText`    | string  | empty string                           | The initial Changelog text.            |
+| `changelog.initialTextUrl` | string  | `https://keepachangelog.com/en/1.0.0/` | The initial Changelog text URL.        |
+| `changelog.skipV`          | boolean | `false`                                | Whether to skip `v` in the version.    |

--- a/README.md
+++ b/README.md
@@ -2,11 +2,71 @@
 
 Release Bump handles version bump tasks for a code release.
 
-## Roadmap
+## Features
 
-- [x] Bump Changelog
-- [ ] Bump docblock comments
-- [ ] Add CLI flag configuration
+[View roadmap](https://github.com/paulshryock/release-bump/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
+
+### Bump Changelog
+
+From this:
+
+```bash
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Add my new feature.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- Fix a bug.
+- Fix another bug.
+
+### Security
+```
+
+to this:
+
+```bash
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://example.com/repo/compare/HEAD..1.0.0)
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [1.0.0](https://example.com/repo/releases/tags/v1.0.0) - 3/30/2021
+
+### Added
+- Add my new feature.
+
+### Fixed
+- Fix a bug.
+- Fix another bug.
+```
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "arg": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.0.tgz",
+      "integrity": "sha512-4P8Zm2H+BRS+c/xX1LrHw0qKpEhdlZjLCgWy+d78T9vqa2Z2SiD2wMrYuWIAFy5IZUD7nnNXroRttz+0RzlrzQ=="
+    },
     "axios": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "postversion": "git push && git push --tags && npm publish"
   },
   "dependencies": {
+    "arg": "^5.0.0",
     "axios": "^0.21.1",
     "deepmerge": "^4.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   "author": "Paul Shryock <paul@pshry.com> (https://github.com/paulshryock)",
   "main": "src/bump.js",
   "bin": {
-    "release-bump": "cli.js"
+    "release-bump": "src/cli.js"
   },
   "scripts": {
-    "version": "node cli.js && git add ."
+    "version": "node src/cli.js && git add .",
+    "postversion": "git push && git push --tags && npm publish"
   },
   "dependencies": {
     "axios": "^0.21.1",

--- a/src/bump.js
+++ b/src/bump.js
@@ -1,7 +1,9 @@
-const deepmerge = require('deepmerge')
-// @todo: Include a deepmerge utility instead of a dependency.
-// @see: https://thewebdev.info/2021/03/06/how-to-deep-merge-javascript-objects/
 const Changelog = require('./changelog.js')
+const defaults = require('./defaults.js')
+const arg = require('arg')
+const deepmerge = require('deepmerge')
+// @todo: Use a deepmerge utility instead of a dependency.
+// @see: https://thewebdev.info/2021/03/06/how-to-deep-merge-javascript-objects/
 
 /**
  * Bump class.
@@ -13,34 +15,47 @@ module.exports = class Bump {
   /**
    * Bump class constructor.
    *
-   * @param {Object} options Configuration options.
+   * @param {Object} config Configuration options.
    * @since 1.0.0
    */
-  constructor(options = {}) {
-    this.options = options
+  constructor(config = {}) {
+    // Define CLI args.
+    this.args = arg({
+      '--changelog-file-path': String,
+      '-p': '--changelog-file-path',
+
+      '--git-remote': String,
+      '-r': '--git-remote',
+
+      '--skip-v-in-version': Boolean,
+      '--skip-v': '--skip-v-in-version',
+      '-s': '--skip-v-in-version',
+
+      '--initial-changelog-text': String,
+      '-t': '--initial-changelog-text',
+
+      '--initial-changelog-text-url': String,
+      '-u': '--initial-changelog-text-url',
+    })
+
+    // Get CLI arg values.
+    this.argv = { changelog: {} }
+    if (this.args['--changelog-file-path']) this.argv.changelog.filePath = this.args['--changelog-file-path']
+    if (this.args['--skip-v-in-version']) this.argv.changelog.skipV = this.args['--skip-v-in-version']
+    if (this.args['--initial-changelog-text']) this.argv.changelog.initialText = this.args['--initial-changelog-text']
+    if (this.args['--initial-changelog-text-url']) this.argv.changelog.initialTextUrl = this.args['--initial-changelog-text-url']
+    if (this.args['--git-remote']) this.argv.changelog.gitRemote = this.args['--git-remote']
+
+    // Setup defaults.
+    this.defaults = defaults
+
+    // Merge passed config object with defaults.
+    this.config = deepmerge(this.defaults, config)
+
+    // Merge CLI args with config.
+    this.options = deepmerge(this.config, this.argv)
 
     // Setup Changelog.
-    this.changelog()
-  }
-
-  /**
-   * Setup Changelog.
-   *
-   * @since 1.0.0
-   */
-  changelog() {
-    const defaults = {
-      filePath: './CHANGELOG.md',
-      includeV: true,
-      initialText: '',
-      initialTextUrl: 'https://keepachangelog.com/en/1.0.0/',
-      remote: 'github',
-    }
-    
-    new Changelog(
-      this.options.changelog
-        ? deepmerge(defaults, this.options.changelog)
-        : defaults
-    )
+    new Changelog(this.options.changelog)
   }
 }

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -1,6 +1,6 @@
-const fs = require('fs')
-// @todo: Use fetch instead of a dependency.
 const axios = require('axios')
+// @todo: Use fetch instead of a dependency.
+const fs = require('fs')
 
 /**
  * Changelog class.
@@ -13,13 +13,13 @@ module.exports = class Changelog {
    * Changelog class constructor.
    *
    * @param {string}  options.filePath       The Changelog file path.
-   * @param {boolean} options.includeV       Whether to include v in the version.
+   * @param {string}  options.gitRemote      The Git remote. (`github`|`bitbucket`)
    * @param {string}  options.initialText    The initial Changelog text.
    * @param {string}  options.initialTextUrl The initial Changelog text URL.
-   * @param {string}  options.remote         Accepts 'github' or 'bitbucket'.
+   * @param {boolean} options.skipV          Whether to skip v in the version.
    * @since 1.0.0
    */
-  constructor({ filePath, includeV, initialText, initialTextUrl, remote }) {
+  constructor({ filePath, gitRemote, initialText, initialTextUrl, skipV }) {
     const { version, repository } = JSON.parse(fs.readFileSync('./package.json', 'utf8'))
     if (!version || !repository || !repository.url) {
       console.error('version or repository url is missing from package.json.')
@@ -33,12 +33,12 @@ module.exports = class Changelog {
       .replace(/\.git(#.*$)?/, '')
     this.today = `${month}/${date}/${year}`
     this.filePath = filePath
-    this.includeV = includeV
+    this.gitRemote = gitRemote.toLowerCase()
     this.initialText = initialText
     this.initialTextUrl = initialTextUrl
-    this.remote = remote.toLowerCase()
+    this.skipV = skipV
     this.unreleased =
-      `## [Unreleased](${this.repository}/${this.remote === 'bitbucket' ? 'branches/' : ''}compare/HEAD..${this.version})` +
+      `## [Unreleased](${this.repository}/${this.gitRemote === 'bitbucket' ? 'branches/' : ''}compare/HEAD..${this.version})` +
       '\n\n### Added' +
       '\n\n### Changed' +
       '\n\n### Deprecated' +
@@ -146,8 +146,8 @@ module.exports = class Changelog {
    */
   bump () {
     this.header = `## [${this.version}](${this.repository}/` +
-      `${this.remote === 'bitbucket' ? 'commits/tag' : 'releases/tags'}/` +
-      `${this.includeV ? 'v' : ''}${this.version}) - ${this.today}`
+      `${this.gitRemote === 'bitbucket' ? 'commits/tag' : 'releases/tags'}/` +
+      `${this.skipV ? '' : 'v'}${this.version}) - ${this.today}`
 
     this.write(this.text
       // Bump unreleased version and add today's date.

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -27,7 +27,10 @@ module.exports = class Changelog {
     }
     const [month, date, year] = new Date().toLocaleDateString('en-US').split('/')
     this.version = version
-    this.repository = repository.url.replace('git+', '').replace('.git', '')
+    this.repository = repository.url
+      .replace(`^git\+?`, '')
+      .replace(/^(ssh)?:\/\//, 'https://')
+      .replace(/\.git(#.*$)?/, '')
     this.today = `${month}/${date}/${year}`
     this.filePath = filePath
     this.includeV = includeV

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,16 +1,5 @@
 #!/usr/bin/env node
 (function () {
   const Bump = require('./bump.js')
-
-  /**
-   * Initialize Release Bump.
-   *
-   * @since 1.0.0
-   */
-  async function init () {
-    new Bump()
-  }
-
-  // Initialize Release Bump.
-  init()
+  new Bump()
 })()

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 (function () {
-  const Bump = require('./src/bump.js')
+  const Bump = require('./bump.js')
 
   /**
    * Initialize Release Bump.

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,0 +1,15 @@
+/**
+ * Configuration defaults.
+ *
+ * @since 1.0.0
+ * @type  {Object}
+ */
+module.exports = {
+  changelog: {
+    filePath: './CHANGELOG.md',
+    gitRemote: 'github',
+    initialText: '',
+    initialTextUrl: 'https://keepachangelog.com/en/1.0.0/',
+    skipV: false,
+  },
+}


### PR DESCRIPTION
## Summary
This change allows CLI configuration by passing any of the following flags:

| Option | Type    | Default                                | Description                            |
| :---   | :---    | :---                                   | :---                                   |
| `-p`   | string  | `./CHANGELOG.md`                       | The Changelog file path.               |
| `-r`   | string  | `github`                               | The Git remote. (`github`|`bitbucket`) |
| `-s`   | boolean | `false`                                | Whether to skip `v` in the version.    |
| `-t`   | string  | empty string                           | The initial Changelog text.            |
| `-u`   | string  | `https://keepachangelog.com/en/1.0.0/` | The initial Changelog text URL.        |

## Changelog
### Added
- Add CLI flag configuration. [#4]

## Testing
- Run `npm link` to allow running `release-bump` locally
- From a test repo, run `release-bump` with CLI flags and verify the results

## Ticket
Closes #4

## Screenshot(s)
N/A

## Checklist
- [x] I have tested the code in this pull request.
- [x] I have updated the Changelog.
- [x] I have documented any new features or changes in the Readme.