### PR TITLE
[#12]: Fix release tags typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix release tags typo. [#12]
 
 ### Security
 
-## [1.2.0](https://github.com/paulshryock/release-bump/releases/tags/v1.2.0) - 4/5/2021
+## [1.2.0](https://github.com/paulshryock/release-bump/releases/tag/v1.2.0) - 4/5/2021
 
 ### Added
 - Get package version from CLI. [#7]
@@ -28,12 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Better logging.
 - Cancel Changelog bump if file does not exist.
 
-## [1.1.0](https://github.com/paulshryock/release-bump/releases/tags/v1.1.0) - 4/2/2021
+## [1.1.0](https://github.com/paulshryock/release-bump/releases/tag/v1.1.0) - 4/2/2021
 
 ### Added
 - Add CLI flag configuration. [#4]
 
-## [1.0.0](https://github.com/paulshryock/release-bump/releases/tags/v1.0.0) - 3/30/2021
+## [1.0.0](https://github.com/paulshryock/release-bump/releases/tag/v1.0.0) - 3/30/2021
 
 ### Added
 - Bump Changelog.

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -149,7 +149,7 @@ module.exports = class Changelog {
    */
   bump () {
     this.header = `## [${this.version}](${this.repository}/` +
-      `${this.gitRemote === 'bitbucket' ? 'commits/tag' : 'releases/tags'}/` +
+      `${this.gitRemote === 'bitbucket' ? 'commits/tag' : 'releases/tag'}/` +
       `${this.skipV ? '' : 'v'}${this.version}) - ${this.today}`
 
     console.info('Bumping Changelog to:', this.version)


### PR DESCRIPTION
## Summary
The release links in the Changelog have a typo and return a `404` status.
## Changelog
### Fixed
- Fix release tags typo. [#12]
## Testing
- View rendered `CHANGELOG.md` in GitHub
- Confirm release links go to the release instead of returning a `404` status
## Ticket
Closes #12
## Screenshot(s)
N/A
## Checklist
- [x] I have tested the code in this pull request.
- [x] I have updated the Changelog.
- [ ] I have documented any new features or changes in the Readme.
