### PR TITLE
[#2]: Bump WordPress theme version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/paulshryock/release-bump/compare/HEAD..1.2.1)
 
 ### Added
+- Bump WordPress theme version.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,30 @@ to this:
 - Fix another bug.
 ```
 
+### Bump WordPress theme
+
+If your project has a file named `style.css` in the root directory, it will bump the version, if there is one.
+
+`release-bump` will change this:
+
+```css
+/*
+Theme Name: ...
+Version: 0.0.1
+...
+*/
+```
+
+to this:
+
+```css
+/*
+Theme Name: ...
+Version: 1.0.0
+...
+*/
+```
+
 ## Usage
 
 ### Install
@@ -91,6 +115,7 @@ Now whenever you run `npm version <major|minor|patch>`, all of the `release-bump
 | `-t`   | string  | empty string                           | The initial Changelog text.            |
 | `-u`   | string  | `https://keepachangelog.com/en/1.0.0/` | The initial Changelog text URL.        |
 | `-v`   | boolean | `false`                                | Log package version.                   |
+| `-w`   | boolean | `false`                                | Whether to skip WordPress theme bump.  |
 
 ### JavaScript API
 
@@ -114,6 +139,7 @@ new Bump({
     skipV: false,
   },
   help: false,
+  skipWordPress: false,
   version: false,
 })
 ```
@@ -129,4 +155,5 @@ new Bump({
 | `changelog.initialTextUrl` | string  | `https://keepachangelog.com/en/1.0.0/` | The initial Changelog text URL.        |
 | `changelog.skipV`          | boolean | `false`                                | Whether to skip `v` in the version.    |
 | `help`                     | boolean | `false`                                | Whether to log help information.       |
+| `skipWordPress`            | boolean | `false`                                | Whether to skip WordPress theme bump.  |
 | `version`                  | boolean | `false`                                | Whether to log package version.        |

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "release-bump": "src/cli.js"
   },
   "scripts": {
+    "test": "node src/cli.js",
     "version": "node src/cli.js && git add .",
     "postversion": "git push && git push --tags && npm publish"
   },

--- a/src/bump.js
+++ b/src/bump.js
@@ -1,4 +1,5 @@
 const Changelog = require('./changelog.js')
+const WordPress = require('./wordpress.js')
 const defaults = require('./defaults.js')
 const pkg = require('../package.json')
 const fs = require('fs')
@@ -44,6 +45,9 @@ module.exports = class Bump {
 
       '--version': Boolean,
       '-v': '--version',
+
+      '--skip-wordpress': Boolean,
+      '-w': '--skip-wordpress',
     })
 
     // Get CLI arg values.
@@ -54,6 +58,7 @@ module.exports = class Bump {
     if (this.args['--skip-v-in-version']) this.argv.changelog.skipV = this.args['--skip-v-in-version']
     if (this.args['--initial-changelog-text']) this.argv.changelog.initialText = this.args['--initial-changelog-text']
     if (this.args['--initial-changelog-text-url']) this.argv.changelog.initialTextUrl = this.args['--initial-changelog-text-url']
+    if (this.args['--skip-wordpress']) this.argv.skipWordPress = this.args['--skip-wordpress']
     if (this.args['--version']) this.argv.version = this.args['--version']
 
     // Setup defaults.
@@ -69,10 +74,15 @@ module.exports = class Bump {
     if (this.options.help) return this.help()
 
     // Log package version.
-    if (this.options.version) return this.version()
+    if (this.options.version) return this.logPackageVersion()
 
-    // Setup Changelog.
+    // @todo: Get version once and pass it to Changelog and WordPress.
+
+    // Handle Changelog bump.
     new Changelog(this.options.changelog)
+
+    // Handle WordPress bump.
+    new WordPress({ skipWordPress: this.options.skipWordPress })
   }
 
   /**
@@ -81,14 +91,15 @@ module.exports = class Bump {
    * @since unreleased
    */
   help () {
-    const readme = fs.readFileSync('./node_modules/release-bump/README.md', 'utf-8')
+    const path = './node_modules/release-bump/README.md'
+    this.readme = fs.readFileSync(path, 'utf-8')
       // Get CLI documentation.
       .match(/### CLI.*### JavaScript API/s)[0]
       // Filter configuration details.
       .replace(/### CLI.*#### Configuration\n\n/s, '')
       // Remove last line.
       .replace(/\n\n### JavaScript API/s, '')
-    console.info(readme)
+    console.info(this.readme)
   }
 
   /**
@@ -96,7 +107,11 @@ module.exports = class Bump {
    *
    * @since unreleased
    */
-  version () {
-    console.info(pkg.version)
+  logPackageVersion () {
+    if (pkg.version) {
+      console.info(pkg.version)
+    } else {
+      console.warn('No version found.')
+    }
   }
 }

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -21,11 +21,11 @@ module.exports = class Changelog {
   constructor({ filePath, gitRemote, initialText, initialTextUrl, skipV }) {
     const { version, repository } = JSON.parse(fs.readFileSync('./package.json', 'utf8'))
     if (!version) {
-      console.error('version is missing from package.json.')
+      console.error('Missing package.json version. Can not bump.')
       return
     }
     if (!repository || !repository.url) {
-      console.error('repository url is missing from package.json.')
+      console.error('Missing package.json repository url. Can not bump.')
       return
     }
     const [month, date, year] = new Date().toLocaleDateString('en-US').split('/')

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -13,5 +13,6 @@ module.exports = {
     skipV: false,
   },
   help: false,
+  skipWordPress: false,
   version: false,
 }

--- a/src/wordpress.js
+++ b/src/wordpress.js
@@ -1,0 +1,87 @@
+const axios = require('axios')
+const { readFile, writeFile } = require('fs/promises')
+
+/**
+ * WordPress class.
+ *
+ * @since 1.0.0
+ * @type  {Class}
+ */
+module.exports = class WordPress {
+  /**
+   * WordPress class constructor.
+   *
+   * @param {boolean} skipWordPress Whether to skip WordPress theme bump.
+   * @since unreleased
+   */
+  constructor({ skipWordPress }) {
+    // Bail early.
+    if (skipWordPress) return
+
+    this.filePath = './style.css'
+
+    // Bump WordPress theme version.
+    this.bump()
+  }
+
+  /**
+   * Bump WordPress theme version.
+   *
+   * @since unreleased
+   */
+  async bump () {
+    try {
+      // If there is no text version, bail.
+      const text = await readFile(this.filePath, 'utf8')
+      const versionRegex = /Version: \d*\.?\d*\.?\d*/
+      if (!text.match(versionRegex)) {
+        console.error(`${this.filePath} does not contain a version. Can not bump WordPress theme.`)
+        return
+      }
+
+      // If there is no package version, bail.
+      const pkg = await readFile('./package.json', 'utf8')
+      const { version } = JSON.parse(pkg)
+      if (!version) {
+        console.error(
+          `Missing package.json version. Can not bump.`
+        )
+        return
+      }
+
+      // Bump WordPress theme version.
+      this.version = version
+      this.text = text.replace(versionRegex, `Version: ${this.version}`)
+
+      // Write WordPress theme version.
+      this.write()
+    }
+
+    catch (error) {
+      switch (error.code) {
+        case 'ENOENT': // File does not exist.
+          console.error(`${error.path} does not exist. Can not bump WordPress theme.`)
+          break
+        default:
+          throw error
+          break
+      }
+    }
+  }
+
+  /**
+   * Write WordPress theme version.
+   *
+   * @since unreleased
+   */
+  async write () {
+    try {
+      console.info(`Bumping WordPress theme to ${this.version}.`)
+      writeFile(this.filePath, this.text, 'utf8')
+    }
+
+    catch (error) {
+      console.error(error)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
If the current project is a WordPress theme, bump the theme version.

## Changelog
### Added
- Bump WordPress theme version.

## Testing
- Create a `style.css` file with a WordPress theme comment block including a version
- Run `npm test`
- Confirm that the WordPress theme version is bumped in `style.css`

## Ticket
Closes #2

## Screenshot(s)

## Checklist
- [x] I have tested the code in this pull request.
- [x] I have updated the Changelog.
- [x] I have documented any new features or changes in the Readme.
