### PR TITLE
Fix file util methods, update file tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Update `file` util methods.
 
 ### Deprecated
 

--- a/src/Changelog.test.js
+++ b/src/Changelog.test.js
@@ -114,7 +114,7 @@ test.serial('after setup if file does not exist', async t => {
   t.falsy(changelog.new, 'has no new')
 })
 
-test.serial('after setup if file does exist', async t => {
+test('after setup if file does exist', async t => {
   t.plan(4)
   // Write Changelog.
   await writeChangelog()
@@ -146,6 +146,7 @@ test('after bump', async t => {
   await Promise.all([
     t.assert(file, 'file exists'),
     t.is(getType(file), 'string', 'file contents is a string'),
+    // todo: Pass new version.
     t.assert(file.includes(`[${options.version}]`), 'file has new version'),
   ])
 })

--- a/src/WordPress.js
+++ b/src/WordPress.js
@@ -71,12 +71,12 @@ export default class WordPress {
     try {
       this.plugin = await {
         path: this.paths.plugin,
-        text: await getFileContent({ path: this.paths?.plugin }),
+        text: await getFileContent(this.paths?.plugin),
       }
 
       this.theme = await {
         path: this.paths.theme,
-        text: await getFileContent({ path: this.paths?.theme }),
+        text: await getFileContent(this.paths?.theme),
       }
 
       if (!this.plugin.text && !this.theme.text) {

--- a/src/WordPress.test.js
+++ b/src/WordPress.test.js
@@ -1,7 +1,8 @@
 import test from 'ava'
 import WordPress from './WordPress.js'
+import { getFileContent } from './utils/file.js'
 import { getType } from './utils/type.js'
-import { mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { mkdir, rm, writeFile } from 'fs/promises'
 
 const temp = {
   dir: 'temp/wordpress',
@@ -147,7 +148,7 @@ test('after bump', async t => {
 
   // Test written files.
   for (const type in options.paths) {
-    const file = await readFile(options.paths[type], 'utf8')
+    const file = await getFileContent(options.paths[type])
     await Promise.all([
       t.assert(file, 'file exists'),
       t.is(getType(file), 'string', 'file contents is a string'),

--- a/src/bump.js
+++ b/src/bump.js
@@ -38,7 +38,6 @@ export default class Bump {
       ...defaults.paths,
       ...passed.paths,
     }
-    console.log(this.paths)
   }
 
   /**

--- a/src/bump.js
+++ b/src/bump.js
@@ -122,11 +122,4 @@ export default class Bump {
       $`exit 1`
     }
   }
-
-  /**
-   * Log the class instance to the console.
-   */
-  debug () {
-    console.log(this)
-  }
 }

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -115,7 +115,7 @@ export default class Changelog {
     }
 
     try {
-      const text = await getFileContent({ path: this.path })
+      const text = await getFileContent(this.path)
       if (!text) {
         if (!this.quiet) {
           console.log(chalk.yellow('No Changelog to bump, or Changelog empty.'))

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -1,19 +1,19 @@
-import { constants, readFileSync } from 'fs'
-import { access } from 'fs/promises'
+import { constants } from 'fs'
+import { access, readFile } from 'fs/promises'
 
 /**
  * Check if the file exists in the current directory, and if it is readable.
  *
- * @param  {string}  file The file path.
+ * @param  {string}  path The file path.
  * @return {boolean}      Whether or not the file exists and is readable.
  * @since  2.2.0
  */
-async function fileExists (file) {
-  if (!file) return false
+export async function fileExists (path = '') {
+  if (!path) return false
 
   let exists = true
   try {
-    await access(file, constants.F_OK | constants.R_OK)
+    await access(path, constants.F_OK | constants.R_OK)
   } catch (error) {
     exists = false
   }
@@ -24,30 +24,18 @@ async function fileExists (file) {
 /**
  * Get file content as a string, if it exists.
  *
- * @param  {Object} options      File options.
- * @param  {string} options.path File path.
- * @return {string}              The file content, or an empty string.
+ * @param  {string} path File path.
+ * @return {string}      The file content, or an empty string.
  * @since  2.2.0
- * @todo   Change options argument to path string.
  */
-export async function getFileContent (options = {}) {
-  const { path } = options
-  if (!path) {
-    return null
-  }
+export async function getFileContent (path = '') {
+  // If there is no path, bail.
+  if (!path) return null
 
-  let file = null
-  let exists = false
-  try {
-    // If the file doesn't exist, bail.
-    exists = await fileExists(path)
-    if (!exists) return null
+  // If the file doesn't exist, bail.
+  const exists = await fileExists(path)
+  if (!exists) return null
 
-    // Get the file text.
-    file = readFileSync(path, 'utf8')
-  } catch (error) {
-    return file
-  }
-
-  return file
+  // Get the file text.
+  return await readFile(path, 'utf8')
 }

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -6,7 +6,7 @@ import { access } from 'fs/promises'
  *
  * @param  {string}  file The file path.
  * @return {boolean}      Whether or not the file exists and is readable.
- * @since  unreleased
+ * @since  2.2.0
  */
 async function fileExists (file) {
   if (!file) return false
@@ -27,7 +27,7 @@ async function fileExists (file) {
  * @param  {Object} options      File options.
  * @param  {string} options.path File path.
  * @return {string}              The file content, or an empty string.
- * @since  unreleased
+ * @since  2.2.0
  * @todo   Change options argument to path string.
  */
 export async function getFileContent (options = {}) {

--- a/src/utils/file.test.js
+++ b/src/utils/file.test.js
@@ -1,86 +1,97 @@
 import test from 'ava'
-import { getFileContent } from './file.js'
+import { fileExists, getFileContent } from './file.js'
 import { mkdir, rm, writeFile } from 'fs/promises'
 
-const defaults = {
-  path: 'test.txt',
-  text: 'test',
-}
+const emptyPath = ''
+const goodPath = 'package.json'
+const badPath = goodPath + '1'
 
 const temp = {
   dir: 'temp/file',
 }
 
-const emptyOptions = {}
+const path = `${temp.dir}/${goodPath}`
 
-const badOptions = {
-  path: 1,
+/**
+ * Returns false.
+ *
+ * @param {Object}  t      Assertion object.
+ * @param {Boolean} exists Whether or not file exists.
+ * @since unreleased
+ */
+function returnsFalse (t, exists) {
+  t.plan(1)
+  t.is(exists, false, 'returns false')
 }
 
-const options = {
-  path: `${temp.dir}/${defaults.path}`,
-}
-
-function hasNull (t, content) {
+/**
+ * Returns null.
+ *
+ * @param {Object} t       Assertion object.
+ * @param {Object} content File content.
+ * @since 2.2.0
+ */
+function returnsNull (t, content) {
   t.plan(1)
   t.is(content, null, 'returns null')
 }
 
 /**
- * Write test file.
- *
- * @since 2.2.0
+ * fileExists() tests.
  */
-async function writeTestFile () {
-  await mkdir(temp.dir, { recursive: true })
-  await writeFile(options.path, defaults.text)
-}
 
-test('getFileContent with no options passed', async t => {
-  // Write test file.
-  await writeTestFile()
+test('fileExists with no path', async t => {
+  const exists = await fileExists()
+  returnsFalse(t, exists)
+})
 
+test('fileExists with empty path', async t => {
+  const exists = await fileExists(emptyPath)
+  returnsFalse(t, exists)
+})
+
+test('fileExists with bad path', async t => {
+  const exists = await fileExists(badPath)
+  returnsFalse(t, exists)
+})
+
+test('fileExists with path', async t => {
+  const exists = await fileExists(goodPath)
+  t.plan(1)
+  t.assert(exists, 'returns true')
+})
+
+/**
+ * getFileContent() tests.
+ */
+
+test('getFileContent with no path', async t => {
   const content = await getFileContent()
-  hasNull(t, content)
+  returnsNull(t, content)
 })
 
-test('getFileContent with empty options passed', async t => {
-  // Write test file.
-  await writeTestFile()
-
-  const content = await getFileContent(emptyOptions)
-  hasNull(t, content)
+test('getFileContent with empty path', async t => {
+  const content = await getFileContent(emptyPath)
+  returnsNull(t, content)
 })
 
-test('getFileContent with bad options passed', async t => {
-  // Write test file.
-  await writeTestFile()
-
-  const content = await getFileContent(badOptions)
-  hasNull(t, content)
+test('getFileContent with bad path', async t => {
+  const content = await getFileContent(badPath)
+  returnsNull(t, content)
 })
 
-test.serial(
-  'getFileContent with options passed if file does not exist',
-  async t => {
-    // Remove test file.
-    await rm(options.path, { recursive: true, force: true })
-
-    const content = await getFileContent(options)
-    hasNull(t, content)
-  },
-)
-
-test.serial('getFileContent with options passed if file does exist', async t => {
+test('getFileContent with path', async t => {
   t.plan(1)
 
   // Write test file.
-  await writeTestFile()
+  await mkdir(temp.dir, { recursive: true })
+  const data = await getFileContent(goodPath)
+  await writeFile(path, data)
 
-  const content = await getFileContent(options)
+  const content = await getFileContent(path)
   t.is(
     content,
-    defaults.text,
+    data,
     'path to existing file returns the right text string',
   )
 })


### PR DESCRIPTION
## Summary

Some tests were passing during `npm test` but failing during `npm version`. This fixes failing tests and improves test coverage.

## Changelog

### Changed
- Update `file` util methods.

## Testing

File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------|---------|----------|---------|---------|-------------------------------------------
All files      |   81.04 |    66.32 |   84.21 |   81.04 |
 src           |   79.09 |    60.49 |   81.25 |   79.09 |
  Bump.js      |    78.4 |    66.67 |      50 |    78.4 | 49-59,74-75,103-105,114-124
  Changelog.js |   89.35 |    61.76 |     100 |   89.35 | ...,95-97,114-115,121-122,148-150,165-167
  Git.js       |   85.96 |    76.92 |     100 |   85.96 | 23-25,35-36,53-55
  WordPress.js |   66.03 |    45.45 |      75 |   66.03 | ...06-109,112-120,131-134,137-143,152-154
 src/utils     |     100 |      100 |     100 |     100 |
  file.js      |     100 |      100 |     100 |     100 |
  type.js      |     100 |      100 |     100 |     100 |

## Checklist
- [x] I have tested the code in this pull request.
- [x] I have updated the Changelog.
- [ ] I have documented any new features or changes in the Readme.
