### PR TITLE
[#27]: Bundle/minify JS, replace Changelog.tags.current array w/ latest string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add Node/npm support information. [#27]
+- Bundle and minify JavaScript for dist. [#27]
 
 ### Changed
+- Replace `Changelog.tags.current` array with `Changelog.tags.latest` string.
+- Update dependencies.
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,10 @@
 # `release-bump`
 
-`release-bump` handles version bump tasks for a code release.
-
-## Announcements
-
-Version `2.2.0` adds unit tests, code linting, and [CLI](#cli) and [JavaScript API](#javascript-api) configuration for `quiet`.
-
-Version `2.1.0` adds [CLI](#cli) and [JavaScript API](#javascript-api) configuration for `prefix`.
-
-Version `2.0.0` includes breaking changes:
-- CLI configuration has been removed
-- JavaScript API configuration has been removed
-- [JavaScript class instantiation](#javascript-api) should be followed by a call to `init()` inside an async function.
+Handle version bump tasks for a code release.
 
 ## Requirements
 
-| Software | Minimum version | Tested version | Tested date |
+| Software | Minimum version | Tested up to | Test date |
 | :--- | :--- | :--- | :--- |
 | Node | `^14.14.0` | `16.5.0` | 2021/07/29 |
 | npm | `^3.0.0` | `7.20.3` | 2021/07/29 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "release-bump",
       "version": "2.2.1",
       "license": "Hippocratic 2.1",
       "dependencies": {
         "arg": "^5.0.0",
-        "meow": "^10.1.0",
-        "zx": "^2.0.0"
+        "chalk": "^4.1.1",
+        "meow": "^10.1.0"
       },
       "bin": {
         "release-bump": "cli.js"
@@ -19,10 +20,16 @@
         "@babel/eslint-parser": "^7.14.7",
         "ava": "^3.15.0",
         "c8": "^7.8.0",
+        "esbuild": "^0.12.17",
         "eslint": "^7.31.0",
         "eslint-config-standard": "^16.0.3",
         "eslint-plugin-compat": "^3.11.1",
-        "eslint-plugin-json-files": "^1.1.0"
+        "eslint-plugin-json-files": "^1.1.0",
+        "simple-git": "^2.41.2"
+      },
+      "engines": {
+        "node": ">=14.14.0",
+        "npm": ">=3.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -583,6 +590,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true
+    },
     "node_modules/@mdn/browser-compat-data": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.12.tgz",
@@ -645,14 +667,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@types/fs-extra": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.12.tgz",
-      "integrity": "sha512-I+bsBr67CurCGnSenZZ7v94gd3tc3+Aj2taxMT4yu4ABLuOgOjeFxX3dokG24ztSRg5tnT00sL8BszO7gSMoIw==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
@@ -683,16 +697,8 @@
     "node_modules/@types/node": {
       "version": "16.3.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.3.tgz",
-      "integrity": "sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ=="
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.11.tgz",
-      "integrity": "sha512-2upCKaqVZETDRb8A2VTaRymqFBEgH8u6yr96b/u3+1uQEPDRo3mJLEiPk7vdXBHRtjwkjqzFYMJXrt0Z9QsYjQ==",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
+      "integrity": "sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -975,11 +981,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/ava": {
       "version": "3.15.0",
@@ -1609,17 +1610,6 @@
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -1883,14 +1873,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-indent": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -2060,6 +2042,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.17.tgz",
+      "integrity": "sha512-GshKJyVYUnlSXIZj/NheC2O0Kblh42CS7P1wJyTbbIHevTG4jYMS9NNw8EOd8dDWD0dzydYHS01MpZoUcQXB4g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
       }
     },
     "node_modules/escalade": {
@@ -3011,32 +3003,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3242,7 +3208,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
@@ -3791,7 +3758,8 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -3912,17 +3880,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/keyv": {
@@ -4236,25 +4193,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
-      "dependencies": {
-        "mime-db": "1.48.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
@@ -4296,7 +4234,8 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -4322,14 +4261,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
     },
     "node_modules/node-releases": {
       "version": "1.1.73",
@@ -5427,6 +5358,17 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/simple-git": {
+      "version": "2.41.2",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.41.2.tgz",
+      "integrity": "sha512-rrsqu3w6TNCwe7McW7Uany7pmz5TMteOTCu5Wfc0vVUdKJP94m+587pbEB6Kj4IsBM/vl85nGXZJ3XRSQ9ucLg==",
+      "dev": true,
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.1"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5952,14 +5894,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/update-notifier": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
@@ -6075,6 +6009,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -6216,28 +6151,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/zx/-/zx-2.0.0.tgz",
-      "integrity": "sha512-OF8YvqseMMmtDaASqO+8+0/tJZvykLK0hX9YBAaRO9l7Hc+YjNKjpgJTjrmncgEURoyDr9Ln4r/qBtEuDNZstg==",
-      "dependencies": {
-        "@types/fs-extra": "^9.0.11",
-        "@types/minimist": "^1.2.1",
-        "@types/node": "^16.0",
-        "@types/node-fetch": "^2.5.10",
-        "chalk": "^4.1.1",
-        "fs-extra": "^10.0.0",
-        "minimist": "^1.2.5",
-        "node-fetch": "^2.6.1",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "zx": "zx.mjs"
-      },
-      "engines": {
-        "node": ">= 14.8.0"
       }
     }
   },
@@ -6677,6 +6590,21 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
+    "@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true
+    },
     "@mdn/browser-compat-data": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-3.3.12.tgz",
@@ -6724,14 +6652,6 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@types/fs-extra": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.12.tgz",
-      "integrity": "sha512-I+bsBr67CurCGnSenZZ7v94gd3tc3+Aj2taxMT4yu4ABLuOgOjeFxX3dokG24ztSRg5tnT00sL8BszO7gSMoIw==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
@@ -6762,16 +6682,8 @@
     "@types/node": {
       "version": "16.3.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.3.tgz",
-      "integrity": "sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ=="
-    },
-    "@types/node-fetch": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.11.tgz",
-      "integrity": "sha512-2upCKaqVZETDRb8A2VTaRymqFBEgH8u6yr96b/u3+1uQEPDRo3mJLEiPk7vdXBHRtjwkjqzFYMJXrt0Z9QsYjQ==",
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
+      "integrity": "sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -6983,11 +6895,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "ava": {
       "version": "3.15.0",
@@ -7453,14 +7360,6 @@
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -7664,11 +7563,6 @@
         "slash": "^3.0.0"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
     "detect-indent": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -7800,6 +7694,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "esbuild": {
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.17.tgz",
+      "integrity": "sha512-GshKJyVYUnlSXIZj/NheC2O0Kblh42CS7P1wJyTbbIHevTG4jYMS9NNw8EOd8dDWD0dzydYHS01MpZoUcQXB4g==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -8528,26 +8428,6 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
-    },
-    "fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-      "requires": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -8697,7 +8577,8 @@
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
     },
     "hard-rejection": {
       "version": "2.1.0",
@@ -9063,7 +8944,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -9157,15 +9039,6 @@
       "peer": true,
       "requires": {
         "minimist": "^1.2.5"
-      }
-    },
-    "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
       }
     },
     "keyv": {
@@ -9401,19 +9274,6 @@
         "picomatch": "^2.2.3"
       }
     },
-    "mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
-    },
-    "mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
-      "requires": {
-        "mime-db": "1.48.0"
-      }
-    },
     "mimic-fn": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
@@ -9443,7 +9303,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -9466,11 +9327,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-releases": {
       "version": "1.1.73",
@@ -10240,6 +10096,17 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "simple-git": {
+      "version": "2.41.2",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.41.2.tgz",
+      "integrity": "sha512-rrsqu3w6TNCwe7McW7Uany7pmz5TMteOTCu5Wfc0vVUdKJP94m+587pbEB6Kj4IsBM/vl85nGXZJ3XRSQ9ucLg==",
+      "dev": true,
+      "requires": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.1"
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -10646,11 +10513,6 @@
         "crypto-random-string": "^2.0.0"
       }
     },
-    "universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-    },
     "update-notifier": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
@@ -10750,6 +10612,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -10853,22 +10716,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-    },
-    "zx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/zx/-/zx-2.0.0.tgz",
-      "integrity": "sha512-OF8YvqseMMmtDaASqO+8+0/tJZvykLK0hX9YBAaRO9l7Hc+YjNKjpgJTjrmncgEURoyDr9Ln4r/qBtEuDNZstg==",
-      "requires": {
-        "@types/fs-extra": "^9.0.11",
-        "@types/minimist": "^1.2.1",
-        "@types/node": "^16.0",
-        "@types/node-fetch": "^2.5.10",
-        "chalk": "^4.1.1",
-        "fs-extra": "^10.0.0",
-        "minimist": "^1.2.5",
-        "node-fetch": "^2.6.1",
-        "which": "^2.0.2"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,29 +26,32 @@
   },
   "scripts": {
     "start": "node cli.js -p -q",
+    "lint": "eslint . ./*.cjs src --fix",
+    "build": "esbuild src/Bump.js --bundle --minify --outfile=dist/release-bump.min.cjs --platform=node",
     "pretest": "mkdir -p temp",
     "test": "ava",
     "posttest": "rm -rf temp",
     "test:watch": "ava --watch",
     "test:coverage": "c8 npm test && c8 check-coverage",
-    "lint": "eslint . ./*.cjs src --fix",
     "preversion": "npm run lint && npm run test:coverage",
     "version": "node cli.js -p -q && git add .",
     "postversion": "git push && git push --tags && npm publish"
   },
   "dependencies": {
     "arg": "^5.0.0",
-    "meow": "^10.1.0",
-    "zx": "^2.0.0"
+    "chalk": "^4.1.1",
+    "meow": "^10.1.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.14.7",
     "ava": "^3.15.0",
     "c8": "^7.8.0",
+    "esbuild": "^0.12.17",
     "eslint": "^7.31.0",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-compat": "^3.11.1",
-    "eslint-plugin-json-files": "^1.1.0"
+    "eslint-plugin-json-files": "^1.1.0",
+    "simple-git": "^2.41.2"
   },
   "engines": {
     "node": ">=14.14.0",

--- a/src/Git.js
+++ b/src/Git.js
@@ -1,7 +1,6 @@
-import { $, chalk } from 'zx'
+import chalk from 'chalk'
 import { getType } from './utils/type.js'
-
-$.verbose = false
+import simpleGit from 'simple-git'
 
 export default class Git {
   constructor (options = {}) {
@@ -36,19 +35,15 @@ export default class Git {
     }
 
     try {
-      this.branch = (await $`git branch --show-current`).toString()
-        .replace('\n', '')
+      const git = simpleGit()
+      this.branch = (await git.branch()).current
       this.remote = this.repository
         .replace(/(https?:\/\/|www\.)/g, '')
         .split('/')[0]
         .split('.')[0]
-      this.commit = (await $`git log -n 1 --pretty=format:"%H"`).toString()
-      this.tags = {
-        all: (await $`git tag`).toString().split('\n')
-          .filter(tag => tag !== ''),
-      }
-      this.tags.current = this.tags.all
-        .filter(tag => tag.includes(this.version))
+      // todo: Get short format: git log -n 1 --pretty=format:"%H"
+      this.commit = (await git.log()).latest.hash
+      this.tags = (await git.tags())
     } catch (error) {
       console.error(chalk.red(error))
       throw error

--- a/src/Git.test.js
+++ b/src/Git.test.js
@@ -65,5 +65,5 @@ test('after setup', async t => {
   t.is(getType(git.commit), 'string', 'commit is string')
   t.is(getType(git.tags), 'object', 'tags is object')
   t.is(getType(git.tags.all), 'array', 'all tags is array')
-  t.is(getType(git.tags.current), 'array', 'current tags is array')
+  t.is(getType(git.tags.latest), 'string', 'latest tags is string')
 })

--- a/src/WordPress.js
+++ b/src/WordPress.js
@@ -1,4 +1,4 @@
-import { chalk } from 'zx'
+import chalk from 'chalk'
 import { writeFile } from 'fs/promises'
 import { parse } from 'path'
 import { getFileContent } from './utils/file.js'

--- a/src/bump.js
+++ b/src/bump.js
@@ -1,11 +1,10 @@
-import { $, chalk } from 'zx'
+import chalk from 'chalk'
+import simpleGit from 'simple-git'
 import Git from './Git.js'
 import Changelog from './Changelog.js'
 import WordPress from './WordPress.js'
 import { readFile } from 'fs/promises'
 import { getType } from './utils/type.js'
-
-$.verbose = false
 
 /**
  * Bump class.
@@ -64,11 +63,12 @@ export default class Bump {
     try {
       const pkg = await readFile(this.paths.package, 'utf8')
       const { repository, version } = JSON.parse(pkg.toString())
+      const git = simpleGit()
 
       if (!version) throw new Error('Missing package.json version')
 
       this.repository = repository?.url ||
-        (await $`git remote get-url --push origin`).toString()
+        (await git.remote(['get-url', '--push', 'origin']))
           .replace('\n', '')
       this.repository = 'https://' + this.repository
         .replace(/^git[+@]?/, '')

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -1,4 +1,4 @@
-import { chalk } from 'zx'
+import chalk from 'chalk'
 import { mkdir, writeFile } from 'fs/promises'
 import { parse } from 'path'
 import { getFileContent } from './utils/file.js'


### PR DESCRIPTION
## Summary

Added JS bundling and minification via [esbuild](https://esbuild.github.io/) in preparation for #27.

Removed [zx](https://github.com/google/zx) due to top-level await bundling issue. zx was only used for getting git information and importing [chalk](https://www.npmjs.com/package/chalk).

Added [simple-git](https://github.com/steveukx/git-js) to get git information. simple-git provides a `tags.latest` `string` which has replaced the `tags.current` `array` of `string`s.

Added chalk.

## Changelog

### Added
- Bundle and minify JavaScript for dist. [#27]

### Changed
- Replace `Changelog.tags.current` array with `Changelog.tags.latest` string.
- Update dependencies.

## Testing

34 tests passed

File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------|---------|----------|---------|---------|-------------------------------------------
All files      |   91.17 |    66.67 |     100 |   91.17 |
 src           |   90.19 |    61.54 |     100 |   90.19 |
  Bump.js      |     100 |    70.59 |     100 |     100 | 35,54,68,99,114
  Changelog.js |   97.48 |    65.71 |     100 |   97.48 | 110-111,117-118
  Git.js       |   84.62 |    72.73 |     100 |   84.62 | 22-24,34-35,48-50
  WordPress.js |   76.06 |    46.43 |     100 |   76.06 | ...61,76-77,95-98,101-109,120-123,126-132
 src/utils     |     100 |      100 |     100 |     100 |
  file.js      |     100 |      100 |     100 |     100 |
  type.js      |     100 |      100 |     100 |     100 |

## Ticket
Related to #27

## Checklist
- [x] I have tested the code in this pull request.
- [x] I have updated the Changelog.
- [x] I have documented any new features or changes in the Readme.
